### PR TITLE
NOTASK: Remove carriage returns from Slack messages

### DIFF
--- a/vendors/slack.go
+++ b/vendors/slack.go
@@ -241,7 +241,11 @@ func (s *Slack) prepareMessage(m SlackMessage) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
+	ts := strings.ReplaceAll(m.Message, "\r", "")
+	m.Message = strings.ReplaceAll(ts, "\n", "\\n")
+
 	b := &bytes.Buffer{}
+
 	if err := t.Execute(b, m); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit modifies the slack.go file to strip out carriage returns from the message content. The message is updated to replace all carriage returns ("\r") and newline characters ("\n") with "\\n" to protect json integrity