### PR TITLE
Added countOccurrences and sortOccurrences template functions

### DIFF
--- a/render/template.go
+++ b/render/template.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -372,6 +373,36 @@ func (tpl *Template) FindObjects(obj interface{}, field string, value interface{
 		return r
 	}
 	return r
+}
+
+func (tpl *Template) CountOccurrences(list []interface{}) map[string]int {
+	occurrences := make(map[string]int)
+	for _, item := range list {
+		occurrences[item.(string)]++
+	}
+
+	return occurrences
+}
+
+func (tpl *Template) SortOccurrences(occurrences map[string]int, sep string, count int) []string {
+	keys := make([]string, 0, len(occurrences))
+	for k := range occurrences {
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return occurrences[keys[i]] > occurrences[keys[j]]
+	})
+
+	sortedKeyValues := make([]string, 0, len(keys))
+	for _, k := range keys {
+		sortedKeyValues = append(sortedKeyValues, k+sep+strconv.Itoa(occurrences[k]))
+	}
+
+	if count > len(sortedKeyValues) {
+		return sortedKeyValues
+	}
+	return sortedKeyValues[:count]
 }
 
 // toLower converts the given string (usually by a pipe) to lowercase.
@@ -1934,6 +1965,8 @@ func (tpl *Template) setTemplateFuncs(funcs map[string]any) {
 	funcs["findObject"] = tpl.FindObject
 	funcs["findObjects"] = tpl.FindObjects
 	funcs["findObjectByField"] = tpl.FindObject
+	funcs["countOccurrences"] = tpl.CountOccurrences
+	funcs["sortOccurrences"] = tpl.SortOccurrences
 
 	funcs["replaceAll"] = tpl.ReplaceAll
 	funcs["toLower"] = tpl.ToLower


### PR DESCRIPTION
Basically, a clone of https://github.com/devopsext/chatops/pull/19
I'm now trying to merge this changes to the correct place :P

Let's say we have a slice `["bird", "bird", "bird", "dog", "cat", "cat", "cow", "cow", "cow", "cow"]`

If we use `countOccurrences` from within a template, we get this map:
```
{
    "bird": 3,
    "dog":  1,
    "cat":  2,
    "cow":  4,
}
```

And if we use `sortOccurrences` with the map we got above, and providing a separator string ` occurrences: ` and a limit of 3, we get this slice with the sorted occurrences:
["cow occurrences: 4", "bird occurrences: 3", "cat occurrences: 2"]

Implementing this directly on templates would mean lots of effort, lots of lines and lots of complexity.