### PR TITLE
Allow specifying a PD incident type when creating incidents

### DIFF
--- a/render/template.go
+++ b/render/template.go
@@ -1641,13 +1641,15 @@ func (tpl *Template) PagerDutyCreateIncident(params map[string]interface{}) ([]b
 	urgency, _ := params["urgency"].(string)
 	serviceID, _ := params["serviceID"].(string)
 	priorityID, _ := params["priorityID"].(string)
+	incidentType, _ := params["incidentType"].(string)
 
 	incidentOptions := vendors.PagerDutyIncidentOptions{
-		Title:      title,
-		Body:       body,
-		Urgency:    urgency,
-		ServiceID:  serviceID,
-		PriorityID: priorityID,
+		Title:        title,
+		Body:         body,
+		Urgency:      urgency,
+		ServiceID:    serviceID,
+		PriorityID:   priorityID,
+		IncidentType: incidentType,
 	}
 
 	from, _ := params["from"].(string)

--- a/vendors/pagerduty.go
+++ b/vendors/pagerduty.go
@@ -16,11 +16,12 @@ type PagerDutyCreateIncidentOptions struct {
 }
 
 type PagerDutyIncidentOptions struct {
-	Title      string
-	Body       string
-	Urgency    string
-	ServiceID  string
-	PriorityID string
+	Title        string
+	Body         string
+	Urgency      string
+	ServiceID    string
+	PriorityID   string
+	IncidentType string
 }
 type PagerDutyIncidentNoteOptions struct {
 	IncidentID  string
@@ -47,13 +48,18 @@ type PagerDutyBody struct {
 	Details string `json:"details"`
 }
 
+type PagerDutyIncidentType struct {
+	Name string `json:"name"`
+}
+
 type PagerDutyIncident struct {
-	Type     string             `json:"type"`
-	Title    string             `json:"title"`
-	Urgency  string             `json:"urgency,omitempty"`
-	Service  *PagerDutyService  `json:"service"`
-	Priority *PagerDutyPriority `json:"priority,omitempty"`
-	Body     *PagerDutyBody     `json:"body,omitempty"`
+	Type         string                 `json:"type"`
+	Title        string                 `json:"title"`
+	Urgency      string                 `json:"urgency,omitempty"`
+	Service      *PagerDutyService      `json:"service"`
+	Priority     *PagerDutyPriority     `json:"priority,omitempty"`
+	Body         *PagerDutyBody         `json:"body,omitempty"`
+	IncidentType *PagerDutyIncidentType `json:"incident_type,omitempty"`
 }
 
 type PagerDutyIncidentRequest struct {
@@ -125,6 +131,13 @@ func (pd *PagerDuty) CustomCreateIncident(options PagerDutyOptions, incidentOpti
 		}
 	}
 
+	var incidentType *PagerDutyIncidentType
+	if !utils.IsEmpty(incidentOptions.IncidentType) {
+		incidentType = &PagerDutyIncidentType{
+			Name: incidentOptions.IncidentType,
+		}
+	}
+
 	incident := &PagerDutyIncident{
 		Type:    "incident",
 		Title:   incidentOptions.Title,
@@ -133,8 +146,9 @@ func (pd *PagerDuty) CustomCreateIncident(options PagerDutyOptions, incidentOpti
 			Type: "service_reference",
 			ID:   incidentOptions.ServiceID,
 		},
-		Priority: priority,
-		Body:     body,
+		Priority:     priority,
+		Body:         body,
+		IncidentType: incidentType,
 	}
 
 	request := &PagerDutyIncidentRequest{


### PR DESCRIPTION
These changes allow templates to specify a PD incident type when creating incidents. In essence it means extending the PagerDutyIncident and PagerDutyIncidentOptions structs.